### PR TITLE
added mkdir to fix missing /usr/local/man/man8/

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash 
 
 readonly _dir="$(dirname "$(readlink -f "$0")")"
 
@@ -20,6 +20,8 @@ if [[ "$1" == "install" ]] ; then
   fi
 
   printf "%s\n" "Create man page to /usr/local/man/man8"
+
+  mkdir -p /usr/local/man/man8/
 
   if [[ -e "${_dir}/doc/man8/sandmap.8" ]] ; then
 


### PR DESCRIPTION
Error: 
  Create symbolic link to /usr/local/bin
  Create man page to /usr/local/man/man8
  gzip: /usr/local/man/man8/sandmap.8: Not a directory

Cause:
  gzip tries to compress sandmap.8 but can't find the file as the previous copy step fails due to missing directory.

Solution:
  Create the requried directory prior to copying sandmap.8 over to /usr/local/man/man8